### PR TITLE
Update cuberite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/debian:latest as builder
+FROM hilschernetpi/netpi-raspbian:latest as builder
 
 WORKDIR /build
 
@@ -23,11 +23,13 @@ RUN git clone https://github.com/bennasar99/ClearLagg.git
 
 
 
-FROM arm32v7/debian:stable-slim
+FROM  hilschernetpi/netpi-raspbian:latest
 
 WORKDIR /app
 
-COPY --from=builder /build/cuberite/Release/Server/* .
+COPY --from=builder /build/cuberite/Server/ .
+COPY --from=builder /build/cuberite/Release/Server/lua .
+COPY --from=builder /build/cuberite/Release/Server/Cuberite .
 
 COPY ./config/* .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM hilschernetpi/netpi-raspbian:latest as builder
-
-WORKDIR /build
+FROM --platform=linux/amd64 debian:stable as builder
 
 RUN apt-get update && \
-    apt-get install -y git gcc g++ make cmake
+    apt-get install -y git python3 make cmake g++-arm-linux-gnueabihf
+
+WORKDIR /build
 
 RUN git clone --recursive https://github.com/cuberite/cuberite.git
 
@@ -13,8 +13,19 @@ RUN git reset 8a763d3bedac3eabee9c1ca022be53038ba3fc54 --hard
 
 WORKDIR /build/cuberite/Release
 
-RUN cmake -DCMAKE_BUILD_TYPE=RELEASE .. && \
-    make -j`nproc`
+# GCC compiler flags for ARM CPUs: https://gist.github.com/fm4dd/c663217935dc17f0fc73c9c81b0aa845
+# flags below are compatible with RPi 3 & 4
+RUN cmake -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc \
+          -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++ \
+          -DCMAKE_C_FLAGS="-march=armv7-a+fp -mfpu=neon-fp-armv8 -mfloat-abi=hard" \
+          -DCMAKE_CXX_FLAGS="-march=armv7-a+fp -mfpu=neon-fp-armv8 -mfloat-abi=hard" \
+          -DCMAKE_FIND_LIBRARY_SUFFIXES=".a" \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DCMAKE_EXE_LINKER_FLAGS=-static \
+          -DNO_NATIVE_OPTIMIZATION=1 \
+          -DCMAKE_BUILD_TYPE=RELEASE ..
+
+RUN make -j`nproc`
 
 # Install Plugins here (need to be enabled in settings.ini)
 WORKDIR /build/cuberite/Release/Server/Plugins
@@ -23,7 +34,7 @@ RUN git clone https://github.com/bennasar99/ClearLagg.git
 
 
 
-FROM  hilschernetpi/netpi-raspbian:latest
+FROM arm32v7/debian:stable-slim
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/debian:buster-slim
+FROM arm32v7/debian:stable-slim
 #arm Cuberite is dynamically linked to some armhf deps which we need in the container 
 
 ENV WEB_ADMIN_USER=admin
@@ -8,7 +8,8 @@ RUN apt-get update && \
     apt-get install -y curl rsync git
 
 WORKDIR /app
-RUN curl -sSfL https://download.cuberite.org | sh
+RUN curl https://raw.githubusercontent.com/cuberite/cuberite/master/easyinstall.sh --output install.sh
+RUN bash install.sh
 
 COPY ./config/* /app/
 
@@ -24,6 +25,6 @@ RUN useradd -ms /bin/bash cuberite
 RUN chown -R cuberite:cuberite /app
 USER cuberite
 
-CMD ./Cuberite 
+CMD /app/Cuberite 
 
 EXPOSE 25565 8080

--- a/config/webadmin.ini
+++ b/config/webadmin.ini
@@ -1,2 +1,2 @@
-[User:WEB_ADMIN_USER]
-Password=WEB_ADMIN_PASS
+[User:admin]
+Password=password

--- a/kube/deploy.yaml
+++ b/kube/deploy.yaml
@@ -14,7 +14,7 @@ spec:
         app: cuberite
     spec:
       containers:
-      - image: rhysemmas/cuberite:armv7-3
+      - image: rhysemmas/cuberite:armv7-2023
         imagePullPolicy: Always
         name: server
         resources:

--- a/kube/deploy.yaml
+++ b/kube/deploy.yaml
@@ -14,7 +14,7 @@ spec:
         app: cuberite
     spec:
       containers:
-      - image: rhysemmas/cuberite:armv7-2023
+      - image: rhysemmas/cuberite:arm32v7
         imagePullPolicy: Always
         name: server
         resources:


### PR DESCRIPTION
Certs went out of date again and so now authentication does not work with session server: https://github.com/cuberite/cuberite/pull/5456 (8a763d3bedac3eabee9c1ca022be53038ba3fc54)

Can workaround by disabling authentication but is a bit gross

Seeing issues when using a newer version of Cuberite on startup, errors like:
```
[14:30:02] DeadlockDetect: Some CS objects (2) haven't been removed from tracking        
[14:30:02]   CS 0xb4bad418 / World world chunkmap                                                                                                                                  
[14:30:02]   CS 0xb52fe638 / World world tasks                                           
```

Tried removing existing `world` and letting it start anew, but get the same error so perhaps is an issue with the version I've downloaded rather than the world save

Will try and compile cuberite at some point from the commit that fixes the certs, then update my image to include that version

https://github.com/cuberite/cuberite/blob/master/COMPILING.md#linux-freebsd-etc